### PR TITLE
Update adafruit_as7341.py

### DIFF
--- a/adafruit_as7341.py
+++ b/adafruit_as7341.py
@@ -617,7 +617,7 @@ class AS7341:  # pylint:disable=too-many-instance-attributes
     @led_current.setter
     @_low_bank
     def led_current(self, led_curent):
-        new_current = max(0, min(127,int((led_curent - 4) / 1)))
+        new_current = max(0, min(127,int((led_curent - 4) / 2)))
         self._led_current_bits = new_current
 
     @property

--- a/adafruit_as7341.py
+++ b/adafruit_as7341.py
@@ -617,7 +617,7 @@ class AS7341:  # pylint:disable=too-many-instance-attributes
     @led_current.setter
     @_low_bank
     def led_current(self, led_curent):
-        new_current = int((led_curent - 4) / 2)
+        new_current = max(0, min(127,int((led_curent - 4) / 1)))
         self._led_current_bits = new_current
 
     @property


### PR DESCRIPTION
coerce new_current to between 0 and 127 to avoid wrap-around when led_current=0
avoids the unexpected result of led_current=0 producing maimum brightness