### PR TITLE
Specify minimum Blinka version for typing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-Adafruit-Blinka
+Adafruit-Blinka>=6.20.4
 adafruit-circuitpython-busdevice
 adafruit-circuitpython-register

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
     install_requires=[
-        "Adafruit-Blinka",
+        "Adafruit-Blinka>=6.20.4",
         "adafruit-circuitpython-busdevice",
         "adafruit-circuitpython-register",
     ],


### PR DESCRIPTION
Per discussion with @dhalbert in Discord, this PR specifies a minimum version of 6.20.4 for Blinka. This change is made in both `setup.py` and `requirements.txt` and should alleviate some of the challenges around adding type hints.