### PR TITLE
using _all_channels to update efficiently

### DIFF
--- a/adafruit_as7341.py
+++ b/adafruit_as7341.py
@@ -436,13 +436,13 @@ class AS7341:  # pylint:disable=too-many-instance-attributes, no-member
     @property
     def channel_clear(self) -> int:
         """The current reading for the clear sensor"""
-        self._all_channels
+        _ = self._all_channels
         return self._channel_4_data
 
     @property
     def channel_nir(self) -> int:
         """The current reading for the NIR (near-IR) sensor"""
-        self._all_channels
+        _ = self._all_channels
         return self._channel_5_data
 
     def _wait_for_data(self, timeout: float = 1.0) -> None:
@@ -465,7 +465,7 @@ class AS7341:  # pylint:disable=too-many-instance-attributes, no-member
         """Configure the sensor to read from elements F1-F4, Clear, and NIR"""
         # disable SP_EN bit while  making config changes
         if self._low_channels_configured:
-            self._all_channels
+            _ = self._all_channels
             return
         self._high_channels_configured = False
         self._flicker_detection_1k_configured = False
@@ -489,7 +489,7 @@ class AS7341:  # pylint:disable=too-many-instance-attributes, no-member
         """Configure the sensor to read from elements F5-F8, Clear, and NIR"""
         # disable SP_EN bit while  making config changes
         if self._high_channels_configured:
-            self._all_channels
+            _ = self._all_channels
             return
 
         self._low_channels_configured = False

--- a/adafruit_as7341.py
+++ b/adafruit_as7341.py
@@ -436,13 +436,13 @@ class AS7341:  # pylint:disable=too-many-instance-attributes, no-member
     @property
     def channel_clear(self) -> int:
         """The current reading for the clear sensor"""
-        self._configure_f5_f8()
+        self._all_channels
         return self._channel_4_data
 
     @property
     def channel_nir(self) -> int:
         """The current reading for the NIR (near-IR) sensor"""
-        self._configure_f5_f8()
+        self._all_channels
         return self._channel_5_data
 
     def _wait_for_data(self, timeout: float = 1.0) -> None:
@@ -465,6 +465,7 @@ class AS7341:  # pylint:disable=too-many-instance-attributes, no-member
         """Configure the sensor to read from elements F1-F4, Clear, and NIR"""
         # disable SP_EN bit while  making config changes
         if self._low_channels_configured:
+            self._all_channels
             return
         self._high_channels_configured = False
         self._flicker_detection_1k_configured = False
@@ -488,6 +489,7 @@ class AS7341:  # pylint:disable=too-many-instance-attributes, no-member
         """Configure the sensor to read from elements F5-F8, Clear, and NIR"""
         # disable SP_EN bit while  making config changes
         if self._high_channels_configured:
+            self._all_channels
             return
 
         self._low_channels_configured = False


### PR DESCRIPTION
When not changing between low and high, the _channel_#_data was not being updated.  Also, the clear and nir data is available when _low_channels_configured, so no need to change to high.